### PR TITLE
Bump org.clojure/clojure from 1.7.0 to 1.9.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[com.badlogicgames.gdx/gdx "1.9.3"]
                  [com.badlogicgames.gdx/gdx-box2d "1.9.3"]
                  [com.badlogicgames.gdx/gdx-bullet "1.9.3"]
-                 [org.clojure/clojure "1.7.0"]]
+                 [org.clojure/clojure "1.9.0"]]
   :repositories [["sonatype"
                   "https://oss.sonatype.org/content/repositories/releases/"]]
   :source-paths ["src"]


### PR DESCRIPTION
Bumps org.clojure/clojure from 1.7.0 to 1.9.0.
Changelog: [https://github.com/clojure/clojure/blob/clojure-1.9.0/changes.md](https://github.com/clojure/clojure/blob/clojure-1.9.0/changes.md).

Security updates
Updated dependency org.clojure:clojure to version 1.9.0

---

Pull request generated by Github Action "Dependabot for Clojure projects". Auto-rebase is currently not supported, so it is recommended to rebase before merging to prevent conflicts.